### PR TITLE
Show most recent sessions first

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -125,6 +125,9 @@ def results(api_key):
     if not res.signedUpMeterPoint:
         error("Sorry, it looks like you haven't a meter point for saving sessions.")
     now = pendulum.now()
+    
+    res.sessions.sort(key=lambda sessions: sessions.startAt, reverse=True)
+    
     all_sessions = res.sessions
     sessions = [session for session in res.sessions if session.id in res.joinedEvents or session.startAt > now]
     if not sessions:


### PR DESCRIPTION
Hi, I usually check this app straight after a session and the latest one always loaded last so I thought I've have a go at reversing it.

No idea if this is the correct way to do this but it seemed to work for me.

Thanks for developing the app!